### PR TITLE
Update stats.dart

### DIFF
--- a/lib/src/stats.dart
+++ b/lib/src/stats.dart
@@ -55,7 +55,7 @@ class Stats<T extends num> extends LightStats<T> {
       sumOfSquaredDiffFromMean += squareDiffFromMean;
     }
 
-    final variance = sumOfSquaredDiffFromMean / count;
+    final variance = sumOfSquaredDiffFromMean / (count-1);
 
     // standardDeviation: sqrt of the variance
     final standardDeviation = math.sqrt(variance);


### PR DESCRIPTION
Seeing how sumOfSquaredDiffFromMean is calculated, we can conclude that we are calculating _Sample Variance_ and not _Population Variance_ (more info => [Stats](https://people.richland.edu/james/lecture/m170/ch03-var.html))
According to the formula for Sample Variance, we should divide sumOfSquaredDiffFromMean by number of observations - 1 i.e. count-1 as updated in my PR. 

Also, this is my first PR ✌😁