### PR TITLE
Prepare v2.2.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - id: install
         name: Install dependencies
         run: dart pub get
-      - run: dart test -x presubmit-only -p vm,chrome
+      - run: dart test -x presubmit-only -p vm,chrome --compiler dart2wasm,dart2js
         if: always() && steps.install.outcome == 'success'
       - run: dart test --run-skipped -t presubmit-only
         if: always() && steps.install.outcome == 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-wip
+## 2.2.0
 
 - Added confidence internal logic:
   - `ConfidenceInterval` class and `ConfidenceLevel` enum.
@@ -7,6 +7,10 @@
 - Added `assert` calls to `LightStats` and `Stats` constructors.
 - Changed the type of `LightStats.average` and `Stats.standardDeviation` to 
   `double`.
+- Deprecations:
+  - `LightStats` will be removed.
+  - `average` deprecated in favor of `mean`.
+  - `median` deprecated everywhere.
 - Require at least Dart 3.7
 
 ## 2.1.0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,8 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
+  errors:
+    deprecated_member_use_from_same_package: ignore
 
 linter:
   rules:

--- a/lib/src/confidence_interval.dart
+++ b/lib/src/confidence_interval.dart
@@ -31,8 +31,8 @@ class ConfidenceInterval extends Stats<double> {
   final double tScore;
   final ConfidenceLevel confidenceLevel;
 
-  double get lowerBound => average - marginOfError;
-  double get upperBound => average + marginOfError;
+  double get lowerBound => mean - marginOfError;
+  double get upperBound => mean + marginOfError;
 
   /// Calculates the [ConfidenceInterval] for [data] given a [confidenceLevel].
   ///
@@ -63,7 +63,7 @@ class ConfidenceInterval extends Stats<double> {
       min: stats.min.toDouble(),
       max: stats.max.toDouble(),
       median: stats.median.toDouble(),
-      average: stats.average,
+      average: stats.mean,
       standardDeviation: stats.standardDeviation,
       marginOfError: marginOfError,
       tScore: tScore,

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -5,6 +5,7 @@ import '../stats.dart';
 extension StatsExtensions<T extends num> on Iterable<T> {
   Stats<T> get stats => Stats<T>.fromData(this);
 
+  @Deprecated('Will be remove in the next major release.')
   LightStats<T> get lightStats => LightStats<T>.fromData(this);
 
   ConfidenceInterval confidenceInterval(ConfidenceLevel confidenceLevel) =>
@@ -29,6 +30,7 @@ extension StatsExtensions<T extends num> on Iterable<T> {
   /// Returns the average (mean) of all values in `this`.
   ///
   /// `this` is only enumerated once.
+  @Deprecated('Will be remove in the next major release. Use `mean` instead.')
   double get average {
     var count = 0;
     num runningSum = 0;
@@ -45,4 +47,6 @@ extension StatsExtensions<T extends num> on Iterable<T> {
 
     return runningSum / count;
   }
+
+  double get mean => average;
 }

--- a/lib/src/light_stats.dart
+++ b/lib/src/light_stats.dart
@@ -7,9 +7,14 @@ import 'util.dart';
 part 'light_stats.g.dart';
 
 @JsonSerializable()
+@Deprecated('Will be remove in the next major release.')
 class LightStats<T extends num> {
   final int count;
+
+  @Deprecated('Will be remove in the next major release. Use `mean` instead.')
   final double average;
+
+  double get mean => average;
 
   @JsonKey(fromJson: fromJsonGeneric, toJson: toJsonGeneric)
   final T min;

--- a/lib/src/stats.dart
+++ b/lib/src/stats.dart
@@ -9,6 +9,7 @@ part 'stats.g.dart';
 
 @JsonSerializable()
 class Stats<T extends num> extends LightStats<T> {
+  @Deprecated('Will be remove in the next major release.')
   final num median;
   final double standardDeviation;
 
@@ -100,7 +101,7 @@ class Stats<T extends num> extends LightStats<T> {
 
     return Stats(
       count,
-      fix(average).toDouble(),
+      fix(mean).toDouble(),
       fix(min),
       fix(max),
       fix(median),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stats
 description: >-
   Calculate common statistical values for a set of numbers: max, min, mean,
   median, standard deviation, and standard error.
-version: 2.2.0-wip
+version: 2.2.0
 repository: https://github.com/kevmoo/stats
 
 environment:

--- a/test/stats_test.dart
+++ b/test/stats_test.dart
@@ -20,7 +20,7 @@ Stats _validateJson<T extends num>(
   }
 
   check(values.sum).equals(expectedSum);
-  check(stats.average).isCloseTo(values.average, 0.0000001);
+  check(stats.mean).isCloseTo(values.average, 0.0000001);
   check(stats.min).equals(values.min);
   check(stats.max).equals(values.max);
   return stats;


### PR DESCRIPTION
Deprecate a bunch of stuff to be removed.
Going to drop median and move to all algorithms that can be calculated
easily without sorting or enumerating the collection many times.

Also add testing on wasm
