### PR TITLE
refactor: privatize ChunkedSink in stats_sinks.dart

### DIFF
--- a/lib/src/stats_sinks.dart
+++ b/lib/src/stats_sinks.dart
@@ -9,11 +9,11 @@ final class StatsConverter extends Converter<num, Stats> {
   Stats convert(num input) => Stats.fromData([input]);
 
   @override
-  Sink<num> startChunkedConversion(Sink<Stats> sink) => ChunkedSink(sink);
+  Sink<num> startChunkedConversion(Sink<Stats> sink) => _ChunkedSink(sink);
 }
 
-final class ChunkedSink extends StatsSink {
-  ChunkedSink(this._target);
+final class _ChunkedSink extends StatsSink {
+  _ChunkedSink(this._target);
 
   final Sink<Stats> _target;
   bool _closed = false;


### PR DESCRIPTION
Make ChunkedSink library-private (_ChunkedSink), as it is an internal concrete subclass only instantiated by startChunkedConversion in stats_sinks.dart.
